### PR TITLE
fix username password credentials on dynamic slaves

### DIFF
--- a/src/main/java/com/microsoft/jenkins/azurecommons/remote/UsernameAuth.java
+++ b/src/main/java/com/microsoft/jenkins/azurecommons/remote/UsernameAuth.java
@@ -26,7 +26,7 @@ public abstract class UsernameAuth {
     public static UsernameAuth fromCredentials(StandardUsernameCredentials credentials) {
         if (credentials instanceof StandardUsernamePasswordCredentials) {
             StandardUsernamePasswordCredentials userPass = (StandardUsernamePasswordCredentials) credentials;
-            return new UsernamePasswordAuth(userPass.getUsername(), userPass.getPassword().getPlainText());
+            return new UsernamePasswordAuth(userPass.getUsername(), userPass.getPassword());
         } else if (credentials instanceof SSHUserPrivateKey) {
             SSHUserPrivateKey userKey = (SSHUserPrivateKey) credentials;
             return new UsernamePrivateKeyAuth(userKey.getUsername(), userKey.getPassphrase(), userKey.getPrivateKeys());

--- a/src/main/java/com/microsoft/jenkins/azurecommons/remote/UsernamePasswordAuth.java
+++ b/src/main/java/com/microsoft/jenkins/azurecommons/remote/UsernamePasswordAuth.java
@@ -18,6 +18,11 @@ public class UsernamePasswordAuth extends UsernameAuth {
         this.password = Secret.fromString(password);
     }
 
+    public UsernamePasswordAuth(String username,Secret password){
+        super(username);
+        this.password = password;
+    }
+
     public Secret getPassword() {
         return password;
     }


### PR DESCRIPTION
In azure-commons-plugin, If we use username/password credentials to get kubeconf from vm, It's not work on dynamic slaves.  Here is the reason.
```
public class UsernamePasswordAuth extends UsernameAuth {
    private final Secret password;

    public UsernamePasswordAuth(String username, String password) {
        super(username);
        this.password = Secret.fromString(password);
    }

    public UsernamePasswordAuth(String username,Secret password){
        super(username);
        this.password = password;
    }

    public Secret getPassword() {
        return password;
    }
}
```
`Secret.fromString` will use Jenkins.getInstance to load secret key from Jenkins Instance. But on dynamic slave, You can get active Jenkins instance. So I add a construct function and just transparent pass password to UsernamePasswordAuth.