### PR TITLE
Add helper methods for job run owner lookup

### DIFF
--- a/azure-commons-core/src/main/java/com/microsoft/jenkins/azurecommons/core/JobContext.java
+++ b/azure-commons-core/src/main/java/com/microsoft/jenkins/azurecommons/core/JobContext.java
@@ -9,6 +9,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.apache.commons.io.IOUtils;
@@ -51,6 +52,17 @@ public class JobContext {
 
     public TaskListener getTaskListener() {
         return taskListener;
+    }
+
+    /**
+     * The owner project of this run.
+     */
+    public Item getOwner() {
+        Run<?, ?> currentRun = getRun();
+        if (currentRun != null) {
+            return currentRun.getParent();
+        }
+        return null;
     }
 
     public EnvVars envVars() {

--- a/azure-commons-plugin/src/main/java/com/microsoft/jenkins/azurecommons/JobContext.java
+++ b/azure-commons-plugin/src/main/java/com/microsoft/jenkins/azurecommons/JobContext.java
@@ -9,6 +9,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.apache.commons.io.IOUtils;
@@ -20,7 +21,10 @@ import java.io.PrintStream;
 
 /**
  * Encapsulates the context for a Jenkins build job.
+ *
+ * @deprecated see {@link com.microsoft.jenkins.azurecommons.core.JobContext}.
  */
+@Deprecated
 public class JobContext {
     private final Run<?, ?> run;
     private final FilePath workspace;
@@ -51,6 +55,17 @@ public class JobContext {
 
     public TaskListener getTaskListener() {
         return taskListener;
+    }
+
+    /**
+     * The owner project of this run.
+     */
+    public Item getOwner() {
+        Run<?, ?> currentRun = getRun();
+        if (currentRun != null) {
+            return currentRun.getParent();
+        }
+        return null;
     }
 
     public EnvVars envVars() {


### PR DESCRIPTION
Add a helper method to `JobContext` that returns the owner of the current job run. This will be used in the scoped credentials lookup for all the dependent plugins.