### PR TITLE
Require Java 8 and Jenkins 2

### DIFF
--- a/azure-commons-plugin/src/main/java/com/microsoft/jenkins/azurecommons/telemetry/AppInsightsClient.java
+++ b/azure-commons-plugin/src/main/java/com/microsoft/jenkins/azurecommons/telemetry/AppInsightsClient.java
@@ -142,7 +142,7 @@ public class AppInsightsClient {
     }
 
     private void putJenkinsInfo(final Map<String, String> properties) {
-        final Jenkins j = Jenkins.getInstance();
+        final Jenkins j = Jenkins.getInstanceOrNull();
         if (j == null) {
             properties.put(AppInsightsConstants.PROP_JENKINS_INSTANCE_ID, "local");
             properties.put(AppInsightsConstants.PROP_JENKINS_VERSION, "local");

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     </modules>
 
     <properties>
-        <jenkins.version>1.625.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.1</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
     <licenses>


### PR DESCRIPTION
Java 7 is end of life since a long time.
The set Jenkins version is the first LTS version that requires Java 8.
For more details see https://jenkins.io/changelog-stable/.