### PR TITLE
Upgrade baseline, java 8, fix maven build

### DIFF
--- a/azure-commons-core/pom.xml
+++ b/azure-commons-core/pom.xml
@@ -30,11 +30,6 @@
             <artifactId>java-jwt</artifactId>
             <version>3.2.0</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/azure-commons-plugin/pom.xml
+++ b/azure-commons-plugin/pom.xml
@@ -60,6 +60,7 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
+                    <minimumJavaVersion>1.8</minimumJavaVersion>
                     <maskClasses>
                         com.google.common.base.
                     </maskClasses>

--- a/azure-commons-plugin/src/main/java/com/microsoft/jenkins/azurecommons/telemetry/AppInsightsClient.java
+++ b/azure-commons-plugin/src/main/java/com/microsoft/jenkins/azurecommons/telemetry/AppInsightsClient.java
@@ -152,7 +152,7 @@ public class AppInsightsClient {
     }
 
     private void putJenkinsInfo(final Map<String, String> properties) {
-        final Jenkins j = Jenkins.getInstance();
+        final Jenkins j = Jenkins.getInstanceOrNull();
         if (j == null) {
             properties.put(AppInsightsConstants.PROP_JENKINS_INSTANCE_ID, "local");
             properties.put(AppInsightsConstants.PROP_JENKINS_VERSION, "local");

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </modules>
 
     <properties>
-        <jenkins.version>2.89.4</jenkins.version>
+        <jenkins.version>2.60.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </modules>
 
     <properties>
-        <jenkins.version>2.60.1</jenkins.version>
+        <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>3.42</version>
     </parent>
 
     <artifactId>azure-commons-parent</artifactId>
@@ -18,8 +18,8 @@
     </modules>
 
     <properties>
-        <jenkins.version>1.625.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.89.4</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
     <licenses>
@@ -60,20 +60,29 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-core</artifactId>
-            <version>${jenkins.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure</artifactId>
             <version>1.3.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>20.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+            <version>2.9.8</version>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -81,6 +90,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.reactivex</groupId>
+                <artifactId>rxjava</artifactId>
+                <version>1.3.8</version>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.7</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>3.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.9.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.9.8</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
Baseline: 2.89.4 to match https://github.com/jenkinsci/windows-azure-storage-plugin/blob/dev/pom.xml#L20

There was a bug in the parent pom version this was at, to do with the findbugs maven plugin that was preventing me from building this project:
```
[ERROR] Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs (findbugs) on project azure-commons-parent: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList -> [Help 1]
```

Upgrading the parent pom fixed this

~half of the azure plugins are already on this jenkins version or above

the rest are either not really active or can be upgraded the next time they need a bump

If anyone is still on such an old version of java / jenkins they are highly unlikely to be updating plugins, most plugins now have a java 8 baseline...