### PR TITLE
update Jackson from 2.9.8 to 2.9.9 CVE-2019-12086

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
https://github.com/jenkinsci/azure-ad-plugin/pull/49