### PR TITLE
Remove dependency range to avoid building changes from time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <properties>
         <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
+        <jackson.version>2.9.9</jackson.version>
     </properties>
 
     <licenses>
@@ -111,17 +112,47 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.0</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.8</version>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-client-runtime</artifactId>
+                <version>1.6.7</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-client-authentication</artifactId>
+                <version>1.6.7</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.3</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>lang-tag</artifactId>
+                <version>1.4.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>7.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
`mvn clean dependency:tree`  get some dependency range like:

```
[INFO] org.jenkins-ci.plugins:azure-credentials:hpi:1.6.2-SNAPSHOT
[INFO] +- com.microsoft.azure:azure:jar:1.19.0:compile
[INFO] |  +- com.microsoft.azure:azure-client-authentication:jar:1.6.4:compile
[INFO] |  |  +- com.microsoft.azure:adal4j:jar:1.6.2:compile
[INFO] |  |  |  \- com.nimbusds:oauth2-oidc-sdk:jar:5.64.4:compile
[INFO] |  |  |     +- net.minidev:json-smart:jar:2.3:compile (version selected from constraint [1.3.1,2.3])
[INFO] |  |  |     |  \- net.minidev:accessors-smart:jar:1.2:compile
[INFO] |  |  |     +- com.nimbusds:lang-tag:jar:1.4.4:compile (version selected from constraint [1.4.3,))
[INFO] |  |  |     \- com.nimbusds:nimbus-jose-jwt:jar:7.2.1:compile (version selected from constraint [5.5,))
```

Manage these dependency ranges to avoid building changes from time to time.